### PR TITLE
Fix RabbitmqClient behaviour typespec

### DIFF
--- a/lib/broadway_rabbitmq/rabbitmq_client.ex
+++ b/lib/broadway_rabbitmq/rabbitmq_client.ex
@@ -9,7 +9,7 @@ defmodule BroadwayRabbitMQ.RabbitmqClient do
            metadata: list(atom())
          }
 
-  @callback init(opts :: any) :: {:ok, queue_name :: String.t(), config} | {:error, any}
+  @callback init(opts :: any) :: {:ok, config} | {:error, any}
   @callback setup_channel(config) :: {:ok, Channel.t()} | {:error, any}
   @callback ack(channel :: Channel.t(), delivery_tag :: Basic.delivery_tag()) :: any
   @callback reject(channel :: Channel.t(), delivery_tag :: Basic.delivery_tag(), opts :: keyword) ::


### PR DESCRIPTION
init returns a 2-elem tuple, not a 3-elem one