### PR TITLE
Re-initialize client options on every reconnect

### DIFF
--- a/test/broadway_rabbitmq/ampq_client_test.exs
+++ b/test/broadway_rabbitmq/ampq_client_test.exs
@@ -9,7 +9,6 @@ defmodule BroadwayRabbitMQ.AmqpClientTest do
               %{
                 connection: [],
                 qos: [prefetch_count: 50],
-                requeue: :always,
                 metadata: [],
                 bindings: [],
                 declare_opts: nil,
@@ -52,7 +51,6 @@ defmodule BroadwayRabbitMQ.AmqpClientTest do
                 %{
                   connection: connection,
                   qos: qos,
-                  requeue: :always,
                   metadata: metadata,
                   bindings: [],
                   declare_opts: nil,
@@ -114,22 +112,6 @@ defmodule BroadwayRabbitMQ.AmqpClientTest do
 
       assert {:ok, config} = AmqpClient.init(queue: "", declare: [])
       assert config.queue == ""
-    end
-
-    # TODO: remove this test once we remove support for :requeue.
-    test ":requeue should be :never, :always or :once" do
-      ExUnit.CaptureIO.capture_io(:stderr, fn ->
-        {:ok, opts} = AmqpClient.init(queue: "queue", requeue: :never)
-        assert opts[:requeue] == :never
-        {:ok, opts} = AmqpClient.init(queue: "queue", requeue: :always)
-        assert opts[:requeue] == :always
-        {:ok, opts} = AmqpClient.init(queue: "queue", requeue: :once)
-        assert opts[:requeue] == :once
-        {:error, reason} = AmqpClient.init(queue: "queue", requeue: :unsupported)
-
-        assert reason ==
-                 "expected :queue to be any of [:never, :always, :once], got: :unsupported"
-      end)
     end
 
     test ":metadata should be a list of atoms" do


### PR DESCRIPTION
cc @josevalim @msaraiva 

As discussed with @josevalim. Most of the reasoning is that we don't want to have our producer always try to reconnect to the same URL, so this way we can do random URL on every client reconnect or possibly do even round robin by using eg `persistent_term` or `counter` to store the currently used URL. After working on this, I think it might be beneficial to just support a list of URLs/options as the `:connection` option (or introduce `:connections`) just so that we can have round-robin built-in, but your call :)