### PR TITLE
fix: handle {:error, :not_allowed} connection issue

### DIFF
--- a/lib/broadway_rabbitmq/producer.ex
+++ b/lib/broadway_rabbitmq/producer.ex
@@ -413,6 +413,9 @@ defmodule BroadwayRabbitMQ.Producer do
 
       {:error, :unknown_host} ->
         handle_backoff(state)
+
+      {:error, :not_allowed} ->
+        handle_backoff(state)
     end
   end
 


### PR DESCRIPTION
Recently ran into this error when running this in production trying to connect to a cloudamqp instance, and was resulting in a unmatched clause exception being raised.