### PR TITLE
Fix consume/2 callback

### DIFF
--- a/lib/broadway_rabbitmq/rabbitmq_client.ex
+++ b/lib/broadway_rabbitmq/rabbitmq_client.ex
@@ -6,7 +6,8 @@ defmodule BroadwayRabbitMQ.RabbitmqClient do
   @typep config :: %{
            connection: keyword,
            qos: keyword,
-           metadata: list(atom())
+           metadata: list(atom()),
+           queue: String.t()
          }
 
   @callback init(opts :: any) :: {:ok, config} | {:error, any}
@@ -14,7 +15,7 @@ defmodule BroadwayRabbitMQ.RabbitmqClient do
   @callback ack(channel :: Channel.t(), delivery_tag :: Basic.delivery_tag()) :: any
   @callback reject(channel :: Channel.t(), delivery_tag :: Basic.delivery_tag(), opts :: keyword) ::
               any
-  @callback consume(channel :: Channel.t(), queue_name :: Basic.queue()) :: Basic.consumer_tag()
+  @callback consume(channel :: Channel.t(), config) :: Basic.consumer_tag()
   @callback cancel(channel :: Channel.t(), Basic.consumer_tag()) :: :ok | Basic.error()
   @callback close_connection(conn :: Connection.t()) :: :ok | {:error, any}
 end

--- a/test/broadway_rabbitmq/producer_test.exs
+++ b/test/broadway_rabbitmq/producer_test.exs
@@ -73,7 +73,7 @@ defmodule BroadwayRabbitMQ.ProducerTest do
     end
 
     @impl true
-    def consume(_channel, _queue) do
+    def consume(_channel, _config) do
       :fake_consumer_tag
     end
 


### PR DESCRIPTION
Im the implementation (`AMQPClient`) the queue is get from config: https://github.com/dashbitco/broadway_rabbitmq/blob/78cb281c9a3f7f8b0a81938dc3ec4cafb5449b69/lib/broadway_rabbitmq/amqp_client.ex#L99 
Has the option to change the `consume/2` to accept the queue direct instead of pass the config