### PR TITLE
Add support for the :after_connect option

### DIFF
--- a/lib/broadway_rabbitmq/amqp_client.ex
+++ b/lib/broadway_rabbitmq/amqp_client.ex
@@ -35,7 +35,7 @@ defmodule BroadwayRabbitMQ.AmqpClient do
     with {:ok, merge_opts} <- validate_merge_opts(opts),
          opts = Keyword.merge(opts, merge_opts),
          {:ok, opts} <- validate_supported_opts(opts, "Broadway", @supported_options),
-         {:ok, rabbitmq_setup_fun} <- validate(opts, :rabbitmq_setup_fun, fn _ -> :ok end),
+         {:ok, rabbitmq_setup_fun} <- validate(opts, :rabbitmq_setup_fun, fn _channel -> :ok end),
          {:ok, metadata} <- validate(opts, :metadata, @default_metadata),
          {:ok, queue} <- validate(opts, :queue),
          {:ok, conn_opts} <- validate_conn_opts(opts),
@@ -67,12 +67,8 @@ defmodule BroadwayRabbitMQ.AmqpClient do
     end
   end
 
-  defp call_rabbitmq_setup_fun(%{rabbitmq_setup_fun: nil}, _channel) do
-    :ok
-  end
-
-  defp call_rabbitmq_setup_fun(%{rabbitmq_setup_fun: rabbitmq_setup_fun} = _config, channel) do
-    case rabbitmq_setup_fun.(channel) do
+  defp call_rabbitmq_setup_fun(config, channel) do
+    case config.rabbitmq_setup_fun.(channel) do
       :ok ->
         :ok
 

--- a/lib/broadway_rabbitmq/producer.ex
+++ b/lib/broadway_rabbitmq/producer.ex
@@ -69,6 +69,14 @@ defmodule BroadwayRabbitMQ.Producer do
       if you have multiple RabbitMQ URLs: in that case, you can reconnect to a different
       URL every time you reconnect to RabbitMQ, which avoids the case where the
       producer tries to always reconnect to a URL that is down.
+    * `:after_connect` - a function that takes the AMQP channel that the producer
+      is connected to and can run arbitrary setup. This is useful for declaring
+      complex RabbitMQ topologies with possibly multiple queues, bindings, or
+      exchanges. RabbitMQ declarations are generally idempotent so running this
+      function from all producer stages after every time they connect is likely
+      fine. This function can return `:ok` if everything went well or `{:error, reason}`.
+      In the error case then the producer will consider the connection failed and
+      will try to reconnect later (same behavior as when the connection drops, for example).
 
   > Note: choose the requeue strategy carefully. If you set the value to `:never`
   or `:once`, make sure you handle failed messages properly, either by logging

--- a/test/broadway_rabbitmq/ampq_client_test.exs
+++ b/test/broadway_rabbitmq/ampq_client_test.exs
@@ -4,20 +4,24 @@ defmodule BroadwayRabbitMQ.AmqpClientTest do
   alias BroadwayRabbitMQ.AmqpClient
 
   test "default options" do
-    assert AmqpClient.init(queue: "queue") ==
-             {:ok,
-              %{
-                connection: [],
-                qos: [prefetch_count: 50],
-                metadata: [],
-                bindings: [],
-                declare_opts: nil,
-                queue: "queue"
-              }}
+    assert {:ok,
+            %{
+              connection: [],
+              qos: [prefetch_count: 50],
+              metadata: [],
+              bindings: [],
+              declare_opts: nil,
+              queue: "queue",
+              rabbitmq_setup_fun: rabbitmq_setup_fun
+            }} = AmqpClient.init(queue: "queue")
+
+    assert rabbitmq_setup_fun.(:channel) == :ok
   end
 
   describe "validate init options" do
     test "supported options" do
+      rabbitmq_setup_fun = fn _ -> :ok end
+
       connection = [
         username: nil,
         password: nil,
@@ -41,7 +45,8 @@ defmodule BroadwayRabbitMQ.AmqpClientTest do
       options = [
         queue: "queue",
         connection: connection,
-        qos: qos
+        qos: qos,
+        rabbitmq_setup_fun: rabbitmq_setup_fun
       ]
 
       metadata = []
@@ -54,7 +59,8 @@ defmodule BroadwayRabbitMQ.AmqpClientTest do
                   metadata: metadata,
                   bindings: [],
                   declare_opts: nil,
-                  queue: "queue"
+                  queue: "queue",
+                  rabbitmq_setup_fun: rabbitmq_setup_fun
                 }}
     end
 

--- a/test/broadway_rabbitmq/ampq_client_test.exs
+++ b/test/broadway_rabbitmq/ampq_client_test.exs
@@ -12,15 +12,15 @@ defmodule BroadwayRabbitMQ.AmqpClientTest do
               bindings: [],
               declare_opts: nil,
               queue: "queue",
-              rabbitmq_setup_fun: rabbitmq_setup_fun
+              after_connect: after_connect
             }} = AmqpClient.init(queue: "queue")
 
-    assert rabbitmq_setup_fun.(:channel) == :ok
+    assert after_connect.(:channel) == :ok
   end
 
   describe "validate init options" do
     test "supported options" do
-      rabbitmq_setup_fun = fn _ -> :ok end
+      after_connect = fn _ -> :ok end
 
       connection = [
         username: nil,
@@ -46,7 +46,7 @@ defmodule BroadwayRabbitMQ.AmqpClientTest do
         queue: "queue",
         connection: connection,
         qos: qos,
-        rabbitmq_setup_fun: rabbitmq_setup_fun
+        after_connect: after_connect
       ]
 
       metadata = []
@@ -60,7 +60,7 @@ defmodule BroadwayRabbitMQ.AmqpClientTest do
                   bindings: [],
                   declare_opts: nil,
                   queue: "queue",
-                  rabbitmq_setup_fun: rabbitmq_setup_fun
+                  after_connect: after_connect
                 }}
     end
 


### PR DESCRIPTION
Closes #57.

This PR doesn't test that we actually call the `:after_connect` option but that's because we have a "mock" for the whole `setup_channel/1` function, so we skip testing of all the calls to `AMQP.*` functions. I'll fix that in another PR but the code here is very straightforward luckily :)

cc @josevalim I would love a pair of :eyes: on this! 🙏 