### PR TITLE
Add auth_mechanisms to supported connection options

### DIFF
--- a/lib/broadway_rabbitmq/amqp_client.ex
+++ b/lib/broadway_rabbitmq/amqp_client.ex
@@ -208,7 +208,8 @@ defmodule BroadwayRabbitMQ.AmqpClient do
           :connection_timeout,
           :ssl_options,
           :client_properties,
-          :socket_options
+          :socket_options,
+          :auth_mechanisms
         ]
 
         validate_supported_opts(opts, _group = :connection, supported)


### PR DESCRIPTION
I need to use amqp auth_mechanisms for external authentication, but they are not supported by `BroadwayRabbitMQ.AmqpClient`.

This adds `auth_mechanisms` to the supported connection options.