### PR TITLE
Return opts from the merge validation

### DIFF
--- a/lib/broadway_rabbitmq/amqp_client.ex
+++ b/lib/broadway_rabbitmq/amqp_client.ex
@@ -33,8 +33,7 @@ defmodule BroadwayRabbitMQ.AmqpClient do
 
   @impl true
   def init(opts) do
-    with {:ok, merge_opts} <- validate_merge_opts(opts),
-         opts = Keyword.merge(opts, merge_opts),
+    with {:ok, opts} <- validate_merge_opts(opts),
          {:ok, opts} <- validate_supported_opts(opts, "Broadway", @supported_options),
          {:ok, after_connect} <- validate(opts, :after_connect, fn _channel -> :ok end),
          {:ok, metadata} <- validate(opts, :metadata, @default_metadata),
@@ -142,7 +141,7 @@ defmodule BroadwayRabbitMQ.AmqpClient do
         merge_opts = fun.(index)
 
         if Keyword.keyword?(merge_opts) do
-          {:ok, merge_opts}
+          {:ok, Keyword.merge(opts, merge_opts)}
         else
           message =
             "The :merge_options function should return a keyword list, " <>
@@ -155,7 +154,7 @@ defmodule BroadwayRabbitMQ.AmqpClient do
         {:error, ":merge_options must be a function with arity 1, got: #{inspect(other)}"}
 
       :error ->
-        {:ok, _merge_opts = []}
+        {:ok, opts}
     end
   end
 


### PR DESCRIPTION
Moves the Keyword.merge into the validation. Makes the init function easier to follow.

# Summary

The Keyword.merge is probably behaviour that belongs in the merge validation. This change makes the code easier to follow. Plus I think it's conventional to return opts so that you can continue piping them through validations anyways.

It should be pointed out that @whatyouhide [added a bunch of tests for merge_opts](https://github.com/dashbitco/broadway_rabbitmq/blob/b99105ddcd133d5bf4ba3122b31dc6ba803e905b/test/broadway_rabbitmq/ampq_client_test.exs#L146) and they still pass so I think it's safe to merge.  

## Failed tests

Seems to have failed for some hex related reason, but I'm not sure how to re-run the test. 

![Screenshot 2020-08-04 21 39 01](https://user-images.githubusercontent.com/3220620/89294877-104d5580-d69b-11ea-976b-dfa6e574ea5d.png)
