### PR TITLE
avoid recompilation on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,5 +39,7 @@ jobs:
           mix local.hex --force
           mix deps.get --only test
       - run: mix compile --warnings-as-errors
+        env:
+          MIX_ENV: test
         if: matrix.warnings_as_errors
       - run: mix test


### PR DESCRIPTION
This pull request prevents recompilation on CI as requested on https://github.com/dashbitco/broadway_rabbitmq/pull/70#discussion_r467501609.

[![image](https://user-images.githubusercontent.com/456804/89720124-59f0b580-d9a5-11ea-91a0-1466f90df75a.png)](https://github.com/dashbitco/broadway_rabbitmq/pull/70/checks?check_run_id=962196128)

versus

[![image](https://user-images.githubusercontent.com/456804/89720125-5f4e0000-d9a5-11ea-9a85-ee12d953a1a1.png)](https://github.com/dashbitco/broadway_rabbitmq/pull/72/checks?check_run_id=962378767)

(on the job with `warnings_as_errors: true`)