### PR TITLE
Add more logging in the producer

### DIFF
--- a/test/broadway_rabbitmq/producer_test.exs
+++ b/test/broadway_rabbitmq/producer_test.exs
@@ -447,7 +447,7 @@ defmodule BroadwayRabbitMQ.ProducerTest do
 
       producer = get_producer(broadway)
 
-      send(producer, {:basic_cancel, %{delievery_tag: "my-delivery-tag"}})
+      send(producer, {:basic_cancel, %{consumer_tag: :fake_consumer_tag}})
 
       assert_receive {:setup_channel, :ok, channel_2}
 


### PR DESCRIPTION
Doing `Logger.error(Exception.format(...))` is confusing because it looks exactly like a crash, but we are trapping it, so it's not really "a crash". I rephrased the logging, what do you folks think?

I took the chance to have a bit more logging in place in general.