### PR TITLE
Include AMQP channel in the message metadata

### DIFF
--- a/lib/broadway_rabbitmq/producer.ex
+++ b/lib/broadway_rabbitmq/producer.ex
@@ -214,7 +214,7 @@ defmodule BroadwayRabbitMQ.Producer do
 
     * `:routing_key` - the name of the queue from which the message was consumed.
 
-    * `:message_count` - the current number of messages in the queue
+    * `:message_count` - the current number of messages in the queue.
 
     * `:content_type` - the MIME type of the message.
 
@@ -235,7 +235,7 @@ defmodule BroadwayRabbitMQ.Producer do
 
     * `:timestamp` - a timestamp associated with the message.
 
-    * `:type` - message type as a string
+    * `:type` - message type as a string.
 
     * `:user_id` - a user identifier that could have been assigned during message publication.
     RabbitMQ validated this value against the active connection when the message was published.
@@ -243,6 +243,8 @@ defmodule BroadwayRabbitMQ.Producer do
     * `:app_id` - publishing application identifier.
 
     * `:cluster_id` - RabbitMQ cluster identifier.
+
+    * `:reply_to` - name of the reply queue.
 
   """
 

--- a/lib/broadway_rabbitmq/producer.ex
+++ b/lib/broadway_rabbitmq/producer.ex
@@ -34,8 +34,7 @@ defmodule BroadwayRabbitMQ.Producer do
        random exponential (default: `:rand_exp`)
     * `:metadata` - The list of AMQP metadata fields to copy (default: `[]`). Note
       that every `Broadway.Message` contains an `:amqp_channel` in its `metadata` field.
-      It contains the `AMQP.Channel` struct. You can use it to do things like
-      publish messages back to RabbitMQ (for use cases such as RPCs).
+      See the "Metadata" section below.
     * `:declare` - Optional. A list of options used to declare the `:queue`. The
       queue is only declared (and possibly created if not already there) if this
       option is present and not `nil`. Note that if you use `""` as the queue
@@ -202,6 +201,13 @@ defmodule BroadwayRabbitMQ.Producer do
   You can retrieve additional information about your message by setting the `:metadata` option.
   This is useful in a handful of situations like when you are interested in the message headers
   or in knowing if the message is new or redelivered.
+
+  These are the keys in the metadata map that are *always present*:
+
+    * `:amqp_channel` - It contains the `AMQP.Channel` struct. You can use it to do things
+      like publish messages back to RabbitMQ (for use cases such as RPCs). You *should not*
+      do things with the channel other than publish messages with `AMQP.Basic.publish/5`. Other
+      operations may result in undesired effects.
 
   Here is the list of all possible values supported by `:metadata`:
 

--- a/test/broadway_rabbitmq/producer_test.exs
+++ b/test/broadway_rabbitmq/producer_test.exs
@@ -217,7 +217,10 @@ defmodule BroadwayRabbitMQ.ProducerTest do
     )
 
     assert_receive {:message_handled, %Message{metadata: meta}, _}
-    assert meta == %{content_type: "FAKE_CONTENT_TYPE", routing_key: "FAKE_ROTING_KEY"}
+    assert map_size(meta) == 3
+
+    assert %{content_type: "FAKE_CONTENT_TYPE", routing_key: "FAKE_ROTING_KEY", amqp_channel: %{}} =
+             meta
   end
 
   test "forward messages delivered by the channel" do


### PR DESCRIPTION
Allows us to do things such as publish messages back to RabbitMQ and stuff like that by reusing the existing connection and channel. One thing I’m not sure about is if I should mention somewhere in the docs that you shouldn't "mess" with this channel in order to avoid screwing up the producer, but maybe folks will get it just fine? :)