### PR TITLE
Raise if acking a message fails

### DIFF
--- a/lib/broadway_rabbitmq/producer.ex
+++ b/lib/broadway_rabbitmq/producer.ex
@@ -456,7 +456,7 @@ defmodule BroadwayRabbitMQ.Producer do
         end)
 
         raise RuntimeError, """
-        Could not ack or reject one or more messages. An example failure is provided. There may be more in logging above.
+        Could not ack or reject one or more messages. An example failure is provided. There may be more in logging.
 
         Message: #{inspect(msg)}
         Reason: #{inspect(reason)}

--- a/lib/broadway_rabbitmq/producer.ex
+++ b/lib/broadway_rabbitmq/producer.ex
@@ -447,7 +447,7 @@ defmodule BroadwayRabbitMQ.Producer do
 
       [{msg, reason} | _other_failures] = failure_messages ->
         Enum.each(failure_messages, fn {msg, reason} ->
-          Logger.info("""
+          Logger.error("""
           Could not ack or reject message.
 
           Message: #{inspect(msg)}

--- a/lib/broadway_rabbitmq/producer.ex
+++ b/lib/broadway_rabbitmq/producer.ex
@@ -445,9 +445,18 @@ defmodule BroadwayRabbitMQ.Producer do
       [] ->
         :ok
 
-      [{msg, reason} | _other_failures] ->
+      [{msg, reason} | _other_failures] = failure_messages ->
+        Enum.each(failure_messages, fn {msg, reason} ->
+          Logger.info("""
+          Could not ack or reject message.
+
+          Message: #{inspect(msg)}
+          Reason: #{inspect(reason)}
+          """)
+        end)
+
         raise RuntimeError, """
-        could not ack/reject message
+        Could not ack or reject one or more messages. An example failure is provided. There may be more in logging above.
 
         Message: #{inspect(msg)}
         Reason: #{inspect(reason)}

--- a/test/broadway_rabbitmq/producer_test.exs
+++ b/test/broadway_rabbitmq/producer_test.exs
@@ -3,7 +3,9 @@ defmodule BroadwayRabbitMQ.ProducerTest do
 
   import ExUnit.CaptureLog
   import ExUnit.CaptureIO
+
   alias Broadway.Message
+  alias BroadwayRabbitMQ.Producer
 
   defmodule FakeChannel do
     use GenServer
@@ -65,6 +67,77 @@ defmodule BroadwayRabbitMQ.ProducerTest do
     def ack(channel, delivery_tag) do
       GenServer.call(channel.pid, :fake_basic_ack)
       send(channel.test_pid, {:ack, delivery_tag})
+    end
+
+    @impl true
+    def reject(channel, delivery_tag, opts) do
+      GenServer.call(channel.pid, :fake_basic_ack)
+      send(channel.test_pid, {:reject, delivery_tag, opts})
+    end
+
+    @impl true
+    def consume(_channel, _config) do
+      :fake_consumer_tag
+    end
+
+    @impl true
+    def cancel(_channel, :fake_consumer_tag_closing) do
+      {:error, :closing}
+    end
+
+    @impl true
+    def cancel(%{test_pid: test_pid}, consumer_tag) do
+      send(test_pid, {:cancel, consumer_tag})
+      {:ok, consumer_tag}
+    end
+
+    @impl true
+    def close_connection(%{test_pid: test_pid}) do
+      send(test_pid, :connection_closed)
+      :ok
+    end
+  end
+
+  defmodule FlakyRabbitmqClient do
+    @behaviour BroadwayRabbitMQ.RabbitmqClient
+
+    @impl true
+    def init(opts) do
+      send(opts[:test_pid], :init_called)
+      {:ok, opts}
+    end
+
+    @impl true
+    def setup_channel(config) do
+      test_pid = config[:test_pid]
+
+      status =
+        Agent.get_and_update(config[:connection_agent], fn
+          [status | rest] ->
+            {status, rest}
+
+          _ ->
+            {:ok, []}
+        end)
+
+      if status == :ok do
+        channel = FakeChannel.new(test_pid)
+        send(test_pid, {:setup_channel, :ok, channel})
+        {:ok, channel}
+      else
+        send(test_pid, {:setup_channel, :error, nil})
+        {:error, :econnrefused}
+      end
+    end
+
+    @impl true
+    def ack(_channel, :error_tuple) do
+      {:error, "Cannot acknowledge, with an error tuple"}
+    end
+
+    @impl true
+    def ack(_channel, _delivery_tag) do
+      raise "Cannot acknowledge"
     end
 
     @impl true
@@ -512,6 +585,58 @@ defmodule BroadwayRabbitMQ.ProducerTest do
     end
   end
 
+  describe "unsuccessful acknowledgement" do
+    test "raise when an error is thrown acknowledging" do
+      {:ok, broadway} =
+        start_broadway(
+          client: FlakyRabbitmqClient,
+          on_success: :ack,
+          on_failure: :reject
+        )
+
+      deliver_messages(broadway, [:fail_to_ack])
+
+      assert_raise(RuntimeError, fn ->
+        Message.ack_immediately(%Message{
+          data: :fail_to_ack,
+          acknowledger:
+            {Producer, {self(), :ref},
+             %{
+               client: FlakyRabbitmqClient,
+               on_success: :ack,
+               on_failure: :reject,
+               delivery_tag: :unused
+             }}
+        })
+      end)
+    end
+
+    test "raise when an error is returned from amqp" do
+      {:ok, broadway} =
+        start_broadway(
+          client: FlakyRabbitmqClient,
+          on_success: :ack,
+          on_failure: :reject
+        )
+
+      deliver_messages(broadway, [:fail_to_ack])
+
+      assert_raise(RuntimeError, fn ->
+        Message.ack_immediately(%Message{
+          data: :fail_to_ack,
+          acknowledger:
+            {Producer, {self(), :ref},
+             %{
+               client: FlakyRabbitmqClient,
+               on_success: :ack,
+               on_failure: :reject,
+               delivery_tag: :error_tuple
+             }}
+        })
+      end)
+    end
+  end
+
   test "close connection on terminate" do
     {:ok, broadway} = start_broadway()
     assert_receive {:setup_channel, :ok, _channel}
@@ -526,6 +651,7 @@ defmodule BroadwayRabbitMQ.ProducerTest do
     on_success = Keyword.get(opts, :on_success, :ack)
     on_failure = Keyword.get(opts, :on_failure, :reject)
     merge_options = Keyword.get(opts, :merge_options, fn _ -> [] end)
+    client = Keyword.get(opts, :client, FakeRabbitmqClient)
 
     {:ok, connection_agent} = Agent.start_link(fn -> connect_responses end)
 
@@ -535,7 +661,7 @@ defmodule BroadwayRabbitMQ.ProducerTest do
       producer: [
         module:
           {BroadwayRabbitMQ.Producer,
-           client: FakeRabbitmqClient,
+           client: client,
            queue: "test",
            test_pid: self(),
            backoff_type: backoff_type,


### PR DESCRIPTION
Please refer to https://github.com/dashbitco/broadway/issues/208 for further background.

`BrowadwayRabbitMQ.Producer.ack_messages/3` both swallows errors that get thrown during message acknowledgement and ignores [the error tuple that `amqp` returns if something went wrong](https://github.com/pma/amqp/blob/master/lib/amqp/basic.ex#L135-L138). This means that if a consumer tries to acknowledge receipt of a message before processing it, but an error occurs during the acknowledgement, messages will get double-processed.

Here we raise the errors after logging and explicitly handle the error tuples from `amqp`.