### PR TITLE
Add support for consume options

### DIFF
--- a/test/broadway_rabbitmq/ampq_client_test.exs
+++ b/test/broadway_rabbitmq/ampq_client_test.exs
@@ -50,7 +50,8 @@ defmodule BroadwayRabbitMQ.AmqpClientTest do
         queue: "queue",
         connection: connection,
         qos: qos,
-        after_connect: after_connect
+        after_connect: after_connect,
+        consume_options: [no_ack: true, exclusive: false]
       ]
 
       metadata = []
@@ -65,7 +66,8 @@ defmodule BroadwayRabbitMQ.AmqpClientTest do
                   bindings: [],
                   declare_opts: nil,
                   queue: "queue",
-                  after_connect: after_connect
+                  after_connect: after_connect,
+                  consume_options: [no_ack: true, exclusive: false]
                 }}
     end
 

--- a/test/broadway_rabbitmq/producer_test.exs
+++ b/test/broadway_rabbitmq/producer_test.exs
@@ -421,7 +421,6 @@ defmodule BroadwayRabbitMQ.ProducerTest do
     end
   end
 
-  @tag :focus
   test "if the :no_ack consume option is true, the acknowledger is set to NoopAcknowledger" do
     {:ok, broadway} = start_broadway(consume_options: [no_ack: true])
     assert_receive {:setup_channel, :ok, _}


### PR DESCRIPTION
We particularly need `no_ack: true` which is the only way to have guaranteed "at most once" processing with RabbitMQ. Seems fair enough to just set the acknowledger to `Broadway.NoopAcknowledger` when `:no_ack` is `true`.