### PR TITLE
Support amqp 2.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -29,7 +29,7 @@ defmodule BroadwayRabbitMQ.MixProject do
   defp deps do
     [
       {:broadway, "~> 0.6.0"},
-      {:amqp, "~> 1.3"},
+      {:amqp, "~> 1.3 or ~> 2.0"},
       {:nimble_options, "~> 0.3.5"},
       {:telemetry, ">= 0.4.2 and < 1.0.0"},
       {:ex_doc, ">= 0.19.0", only: :docs},


### PR DESCRIPTION
As I mentioned [here](https://github.com/dashbitco/broadway_rabbitmq/issues/89), amqp 2.0 would be compatible with Broadway. No other changes required and you can continue supporting 1.x.