### PR TITLE
Support amqp-3.0

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,5 +1,7 @@
 use Mix.Config
 
-config :lager,
-  error_logger_redirect: false,
-  handlers: [level: :critical]
+if :ok == Application.ensure_loaded(:lager) do
+  config :lager,
+    error_logger_redirect: false,
+    handlers: [level: :critical]
+end

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,6 +1,7 @@
 use Mix.Config
 
-if :ok == Application.ensure_loaded(:lager) do
+# ensure_loaded was added in Elixir 1.10
+if Application.load(:lager) in [:ok, {:error, {:already_loaded, :lager}}] do
   config :lager,
     error_logger_redirect: false,
     handlers: [level: :critical]

--- a/mix.exs
+++ b/mix.exs
@@ -21,15 +21,24 @@ defmodule BroadwayRabbitMQ.MixProject do
   end
 
   def application do
-    [
-      extra_applications: [:lager, :logger]
-    ]
+    :ok = Application.ensure_loaded(:amqp)
+    client = List.to_string(Application.spec(:amqp, :vsn))
+
+    if Version.match?(client, ">= 3.0.0-rc.0") do
+      [
+        extra_applications: [:logger]
+      ]
+    else
+      [
+        extra_applications: [:lager, :logger]
+      ]
+    end
   end
 
   defp deps do
     [
       {:broadway, "~> 1.0"},
-      {:amqp, "~> 1.3 or ~> 2.0"},
+      {:amqp, "~> 1.3 or ~> 2.0 or ~> 3.0"},
       {:nimble_options, "~> 0.3.5"},
       {:telemetry, "~> 0.4.3 or ~> 1.0"},
       {:ex_doc, ">= 0.25.0", only: :docs},

--- a/mix.exs
+++ b/mix.exs
@@ -21,18 +21,9 @@ defmodule BroadwayRabbitMQ.MixProject do
   end
 
   def application do
-    :ok = Application.ensure_loaded(:amqp)
-    client = List.to_string(Application.spec(:amqp, :vsn))
-
-    if Version.match?(client, ">= 3.0.0-rc.0") do
-      [
-        extra_applications: [:logger]
-      ]
-    else
-      [
-        extra_applications: [:lager, :logger]
-      ]
-    end
+    [
+      extra_applications: [:logger]
+    ]
   end
 
   defp deps do


### PR DESCRIPTION
Starting from amqp-3.0, lager will no longer be required 🎉

Tested by overriding the dep to allow amqp-3.0-rc.1 and running tests.

https://github.com/pma/amqp/wiki/3.0-Release-Notes