### PR TITLE
Allow nimble_options 0.4.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -30,7 +30,7 @@ defmodule BroadwayRabbitMQ.MixProject do
     [
       {:broadway, "~> 1.0"},
       {:amqp, "~> 1.3 or ~> 2.0 or ~> 3.0"},
-      {:nimble_options, "~> 0.3.5"},
+      {:nimble_options, "~> 0.3.5 or ~> 0.4.0"},
       {:telemetry, "~> 0.4.3 or ~> 1.0"},
       {:ex_doc, ">= 0.25.0", only: :docs},
       {:excoveralls, "~> 0.13.3", only: :test}


### PR DESCRIPTION
Updates nimble options dependency to allow 0.4.0

#110 