### PR TITLE
Update code example for dead-letter exchanges

### DIFF
--- a/lib/broadway_rabbitmq/producer.ex
+++ b/lib/broadway_rabbitmq/producer.ex
@@ -381,6 +381,7 @@ defmodule BroadwayRabbitMQ.Producer do
 
         def start_link(_opts) do
           Broadway.start_link(__MODULE__,
+            name: __MODULE__,
             producer: [
               module: {
                 BroadwayRabbitMQ.Producer,


### PR DESCRIPTION
The existing example raises the following exception:

(ArgumentError) invalid configuration given to Broadway.start_link/2, required option :name not found, received options: [:producer, :processors]