### PR TITLE
Fix closing connection from channel pool

### DIFF
--- a/lib/broadway_rabbitmq/amqp_client.ex
+++ b/lib/broadway_rabbitmq/amqp_client.ex
@@ -383,9 +383,9 @@ defmodule BroadwayRabbitMQ.AmqpClient do
   end
 
   @impl true
-  def close_connection(conn) do
-    if Process.alive?(conn.pid) do
-      Connection.close(conn)
+  def close_connection(config, channel) do
+    if Process.alive?(channel.pid) do
+      close_channel(config, channel)
     else
       :ok
     end

--- a/lib/broadway_rabbitmq/producer.ex
+++ b/lib/broadway_rabbitmq/producer.ex
@@ -668,9 +668,9 @@ defmodule BroadwayRabbitMQ.Producer do
   defp requeue?(:reject_and_requeue, _redelivered), do: true
   defp requeue?(:reject_and_requeue_once, redelivered), do: !redelivered
 
-  defp disconnect(%{channel: channel, client: client} = state) do
+  defp disconnect(%{channel: channel, client: client, config: config} = state) do
     if channel do
-      _ = client.close_connection(channel.conn)
+      _ = client.close_connection(config, channel)
       %{state | channel: nil}
     else
       state

--- a/lib/broadway_rabbitmq/rabbitmq_client.ex
+++ b/lib/broadway_rabbitmq/rabbitmq_client.ex
@@ -1,7 +1,7 @@
 defmodule BroadwayRabbitMQ.RabbitmqClient do
   @moduledoc false
 
-  alias AMQP.{Basic, Channel, Connection}
+  alias AMQP.{Basic, Channel}
 
   @typep config :: %{
            connection: keyword,
@@ -18,5 +18,5 @@ defmodule BroadwayRabbitMQ.RabbitmqClient do
               any
   @callback consume(channel :: Channel.t(), config) :: Basic.consumer_tag()
   @callback cancel(channel :: Channel.t(), Basic.consumer_tag()) :: :ok | Basic.error()
-  @callback close_connection(conn :: Connection.t()) :: :ok | {:error, any}
+  @callback close_connection(config, channel :: Channel.t()) :: :ok | {:error, any}
 end

--- a/test/broadway_rabbitmq/ampq_client_test.exs
+++ b/test/broadway_rabbitmq/ampq_client_test.exs
@@ -295,7 +295,7 @@ defmodule BroadwayRabbitMQ.AmqpClientTest do
 
       AMQP.Channel.close(channel)
       Process.unlink(channel.conn.pid)
-      AmqpClient.close_connection(channel.conn)
+      AMQP.Connection.close(channel.conn)
     end
 
     test "uses an existing queue if :declare is not specified" do

--- a/test/broadway_rabbitmq/producer_test.exs
+++ b/test/broadway_rabbitmq/producer_test.exs
@@ -96,7 +96,7 @@ defmodule BroadwayRabbitMQ.ProducerTest do
     end
 
     @impl true
-    def close_connection(%{test_pid: test_pid}) do
+    def close_connection(_config, %{test_pid: test_pid}) do
       send(test_pid, :connection_closed)
       :ok
     end
@@ -167,7 +167,7 @@ defmodule BroadwayRabbitMQ.ProducerTest do
     end
 
     @impl true
-    def close_connection(%{test_pid: test_pid}) do
+    def close_connection(_config, %{test_pid: test_pid}) do
       send(test_pid, :connection_closed)
       :ok
     end


### PR DESCRIPTION
`AmqpClient.close_connection/1` closes the connection independently if its using channel pool or not.
this causes a lot of errors on application shutdown when using channel pool.